### PR TITLE
Potential fix for code scanning alert no. 12: Server-side request forgery

### DIFF
--- a/app/service.js
+++ b/app/service.js
@@ -27,7 +27,7 @@ function proxyRequest(link, method, headers = {}, body = null, responseType = 'j
         let allowFlag = false;
         try {
             const parsedUrl = new URL(link);
-            if (allowedOrigins.includes(parsedUrl.hostname)) allowFlag = true;
+            if (allowedHosts.includes(parsedUrl.hostname)) allowFlag = true;
         }
         catch (error) {
             reject(error);


### PR DESCRIPTION
Potential fix for [https://github.com/NekoZX123/ArcanumMusic/security/code-scanning/12](https://github.com/NekoZX123/ArcanumMusic/security/code-scanning/12)

To fix the SSRF vulnerability, the code must ensure that the hostname of the URL is validated against the `allowedHosts` allowlist before making the request. Specifically:
1. Replace the incorrect reference to `allowedOrigins` with `allowedHosts` in the `proxyRequest` function.
2. Ensure that the validation logic is robust and correctly checks the hostname of the parsed URL.
3. Optionally, add logging or error handling to provide better feedback when a request is blocked.

This fix ensures that only URLs with hostnames explicitly listed in `allowedHosts` are allowed, mitigating the SSRF risk.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
