### PR TITLE
docs: 补充 Linux 安装与兼容性说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,37 @@ v1.8.0 (Kyrios Internal)
 
 made with TypeScript + Vue.js
 
+## Linux 安装与兼容性说明
+
+当前 Release 提供以下 Linux 安装包:
+
+- `.deb` 安装包
+- `AppImage` 便携包
+
+### 架构
+
+当前 Linux 安装包面向 `x64 / amd64` 架构，不支持 ARM 设备。
+
+### Ubuntu / Debian 安装方法
+
+```bash
+sudo apt install ./arcanummusic_<version>_amd64.deb
+```
+
+例如:
+
+```bash
+sudo apt install ./arcanummusic_1.8.0_amd64.deb
+```
+
+### 如果 `.deb` 无法安装或运行
+
+如果当前发行版上的 `.deb` 安装包存在兼容性问题，建议优先尝试同版本的 `AppImage` 安装包。
+
+### 说明
+
+如果您在 Ubuntu / Debian 或其他 Linux 发行版上遇到安装或运行问题，欢迎在 GitHub 提交 Issue 并附上系统版本、架构和报错信息。
+
 ## 问题修复
 
 - 修复 QQ 音乐 API 加密脚本导致应用无法加载的问题


### PR DESCRIPTION
## 变更内容
- 在 README 中补充 Linux 安装与兼容性说明
- 说明当前 Release 提供的 .deb 与 AppImage 包
- 补充 x64 / amd64 架构说明
- 补充 Ubuntu / Debian 的 .deb 安装示例
- 提示 .deb 兼容性异常时可尝试 AppImage

## 目的
帮助 Linux 用户更快判断安装方式，并减少对 Ubuntu / Debian 支持范围的误解。