### PR TITLE
fix: 加固本地 WebSocket 代理并修复若干确认 Bug

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -269,7 +269,7 @@ async function savePreferences(_, pref) {
     if (!config.generic.appearance.window.rememberSize) {
         preference.window.width = 1000;
         preference.window.height = 650;
-        preference.window.unmaximize();
+        preference.window.isMaximized = false;
     }
     // console.log(`[Debug] Preferences: ${JSON.stringify(preference)}`);
 

--- a/app/webSocket.js
+++ b/app/webSocket.js
@@ -1,8 +1,72 @@
 import { WebSocketServer } from 'ws';
 import fetch from 'node-fetch';
 import { createReadStream, existsSync } from 'fs';
+import path from 'path';
+
+import { getLocalMusicPaths } from './configHelper.js';
 
 const wsServer = new WebSocketServer({ port: 3030 });
+
+// 允许通过 WebSocket 读取的本地音频扩展名
+const AUDIO_EXTENSIONS = new Set(['.mp3', '.flac', '.wav', '.ogg', '.aac', '.wma', '.m4a', '.opus']);
+
+// 网易云桌面端 User-Agent (远程音频流式请求使用)
+const NETEASE_DESKTOP_UA = 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Safari/537.36 Chrome/91.0.4472.164 NeteaseMusicDesktop/3.1.28.205001';
+
+/**
+ * 校验本地文件路径是否位于已配置的本地音乐目录内, 防止任意文件读取
+ * @param {string} filePath 待校验的文件路径
+ * @param {string[]} roots 已配置的本地音乐根目录列表
+ */
+function isWithinRoots(filePath, roots) {
+    const resolved = path.resolve(filePath);
+    return roots.some((root) => {
+        const resolvedRoot = path.resolve(root);
+        const relative = path.relative(resolvedRoot, resolved);
+        return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+    });
+}
+
+/**
+ * 校验远程地址是否安全, 阻止 SSRF (本地回环 / 内网地址 / 非 http(s) 协议)
+ * 公网 http(s) 地址 (各音乐平台 CDN) 仍然放行
+ * @param {string} rawUrl 远程音频地址
+ */
+function isSafeRemoteUrl(rawUrl) {
+    let parsed;
+    try {
+        parsed = new URL(rawUrl);
+    } catch {
+        return false;
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
+
+    const host = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, '');
+    if (host === 'localhost' || host.endsWith('.localhost')) return false;
+    if (host === '::1' || host === '::' || host.startsWith('fe80') || host.startsWith('fc') || host.startsWith('fd')) return false;
+
+    const ipv4 = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+    if (ipv4) {
+        const first = Number(ipv4[1]);
+        const second = Number(ipv4[2]);
+        if (first === 0 || first === 127 || first === 10) return false;      // 未指定 / 回环 / 私有
+        if (first === 169 && second === 254) return false;                   // 链路本地
+        if (first === 192 && second === 168) return false;                   // 私有
+        if (first === 172 && second >= 16 && second <= 31) return false;     // 私有
+    }
+
+    return true;
+}
+
+// 流式转发数据并在结束 / 出错时关闭连接
+function streamToSocket(ws, stream) {
+    stream.on('data', (chunk) => ws.send(chunk));
+    stream.on('end', () => ws.close());
+    stream.on('error', (err) => {
+        console.error(`[WebSocket] Stream error: ${err.message}`);
+        ws.close(1011, err.message);
+    });
+}
 
 function startWebSocket() {
     wsServer.on('connection', (ws) => {
@@ -13,30 +77,42 @@ function startWebSocket() {
                 const filePath = messageStr.slice(8);
                 console.log(`[WebSocket] Local file requested: ${filePath}`);
 
+                // 仅允许读取已配置本地音乐目录内的音频文件 (防止任意文件读取)
+                const ext = path.extname(filePath).toLowerCase();
+                if (!AUDIO_EXTENSIONS.has(ext)) {
+                    console.error(`[WebSocket] Rejected non-audio local file: ${filePath}`);
+                    ws.close(1008, 'File type not allowed');
+                    return;
+                }
+
+                const roots = await getLocalMusicPaths();
+                if (!isWithinRoots(filePath, roots)) {
+                    console.error(`[WebSocket] Rejected local file outside configured music folders: ${filePath}`);
+                    ws.close(1008, 'File path not allowed');
+                    return;
+                }
+
                 if (!existsSync(filePath)) {
                     console.error(`[WebSocket] Local file not found: ${filePath}`);
                     ws.close(1011, 'File not found');
                     return;
                 }
 
-                const readStream = createReadStream(filePath);
-                readStream.on('data', (chunk) => {
-                    ws.send(chunk);
-                });
-                readStream.on('end', () => {
-                    ws.close();
-                });
-                readStream.on('error', (err) => {
-                    console.error(`[WebSocket] Error reading local file: ${err.message}`);
-                    ws.close(1011, err.message);
-                });
+                streamToSocket(ws, createReadStream(filePath));
             }
             else {
                 const targetUrl = messageStr;
+
+                // 阻止 SSRF: 仅允许 http(s) 的公网地址
+                if (!isSafeRemoteUrl(targetUrl)) {
+                    console.error(`[WebSocket] Rejected unsafe remote URL: ${targetUrl}`);
+                    ws.close(1008, 'URL not allowed');
+                    return;
+                }
+
                 fetch(targetUrl, {
                     headers: {
-                        // 'Cookie': 'appver=3.1.28.205001; deviceId=264B24D467368DC38A69A4557CB6FB68307DE15AE0D045569C18; os=pc; osver=Microsoft-Windows-11--build-26100-64bit; NMTID=00OhsH_WTYnykecbEQouvNYd6eUYa4AAAGcyGYihQ; WEVNSM=1.0.0; channel=netease; clientSign=08:00:27:1D:4A:A5@@@VB401cc2dc-9afe258d@@@@@@7cc7ffa1ee8c38928aca5c6209fbc2f586e853ad3ae00ab9dc3bec17528e8551;',
-                        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Safari/537.36 Chrome/91.0.4472.164 NeteaseMusicDesktop/3.1.28.205001'
+                        'User-Agent': NETEASE_DESKTOP_UA
                     }
                 })
                 .then((response) => {
@@ -50,22 +126,9 @@ function startWebSocket() {
                         ws.close(1011, 'Empty response body from upstream');
                         return;
                     }
-                    response.body.on('data', (chunk) => {
-                        // console.log(`[WebSocket] Data received`);
-                        ws.send(chunk);
-                    });
-
-                    response.body.on('end', () => {
-                        ws.close();
-                    });
-
-                    response.body.on('error', (err) => {
-                        console.error(`[WebSocket] Stream error: ${err.message}`);
-                        ws.close(1011, err.message);
-                    });
+                    streamToSocket(ws, response.body);
                 })
                 .catch((err) => {
-                    clearTimeout(timeout);
                     console.error(`[WebSocket] Fetch error: ${err.message}`);
                     ws.close(1011, err.message);
                 });
@@ -73,7 +136,7 @@ function startWebSocket() {
         });
     });
 
-    console.log(`[WebSocket] Server running on http://127.0.0.1:3030/`);
+    console.log(`[WebSocket] Server running on ws://127.0.0.1:3030/`);
 }
 
 function stopWebSocket() {

--- a/src/assets/utilities/accountManager.ts
+++ b/src/assets/utilities/accountManager.ts
@@ -83,9 +83,7 @@ async function storeAccountInfo(platform: string) {
 async function readAccountInfo(platform: string = 'all') {
     if (platform === 'all') {
         const platforms = ['netease', 'qqmusic', 'kuwo', 'kugou'];
-        platforms.forEach(async (plat) => {
-            await readAccountInfo(plat);
-        });
+        await Promise.all(platforms.map((plat) => readAccountInfo(plat)));
         return;
     }
 

--- a/src/assets/utilities/crypto.ts
+++ b/src/assets/utilities/crypto.ts
@@ -39,7 +39,6 @@ async function getNewPassword() {
 }
 async function encrypt(plainText: string) {
     const password = await getNewPassword();
-    console.log(`[Debug] Password: ${password}`);
     const passwordUuid = password.split('#')[1].split('@')[0];
     const salt = CryptoJS.lib.WordArray.random(128 / 8);
 


### PR DESCRIPTION
## 摘要

修复本地 WebSocket 代理（`app/webSocket.js`）的安全问题及若干确认 Bug。详见 #46。

## 改动

**`app/webSocket.js`（安全加固，保持播放功能不变）**
- `file:///` 分支：仅放行**已配置本地音乐目录**内、且为音频扩展名的文件 → 修复任意本地文件读取。
- URL 分支：新增 `isSafeRemoteUrl()`，拦截非 `http(s)` / `localhost` / 回环 / 私有（`10` / `172.16–31` / `192.168` / `169.254`）/ IPv6 内网地址 → 缓解 SSRF；**公网 CDN 地址照常放行**，不影响播放。
- 移除 `catch` 中未声明的 `clearTimeout(timeout)`（原会在 fetch 失败时抛 `ReferenceError`）。
- 删除源码内残留的网易云设备 Cookie 注释。
- 抽出 `streamToSocket()` 复用本地 / 远程两分支的流转发逻辑。

**`app/app.js`**
- `savePreferences` 的 `preference.window.unmaximize()` → `preference.window.isMaximized = false`（`preference.window` 为纯数据对象、无此方法，原会抛 `TypeError`）。

**`src/assets/utilities/crypto.ts`**
- 移除打印账户加密派生口令的 `console.log`。

**`src/assets/utilities/accountManager.ts`**
- `readAccountInfo('all')` 改用 `await Promise.all(...)`，消除登录态加载竞态（原 `forEach(async)` 不会真正 `await`）。

## 兼容性 / 测试

- `app/*.js` 已通过 `node --check` 语法校验。
- WebSocket 改动刻意保持现有协议：`player.ts` 发送的 `file:///<本地音乐目录内文件>` 与公网音频 URL 均不受影响。
- 受环境所限未跑四平台播放回归，建议合并前抽测远程与本地音频播放各一次。

## 关联

涉及 #46（本 PR 涵盖其中第 1–7 项；第 8 项 `quitApp` / `process.exit` 留待讨论，未包含在本 PR）。
